### PR TITLE
Add Mintfile, .swiftlint.yml, and .swiftformat

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,75 @@
+# SwiftFormat configuration
+# Consistent with .swiftlint.yml rules
+
+# Swift version
+--swiftversion 6.2
+
+# Indentation
+--indent 4
+--smarttabs disabled
+--indentcase false
+--ifdef indent
+--indentstrings false
+
+# Braces
+--allman false
+
+# Wrapping
+--wraparguments before-first
+--wrapcollections before-first
+--wrapparameters before-first
+--wrapconditions before-first
+--wrapreturntype preserve
+--wraptypealiases before-first
+--closingparen balanced
+--maxwidth 120
+
+# Spacing
+--operatorfunc spaced
+--nospaceoperators
+--ranges spaced
+--trimwhitespace always
+
+# Blank lines
+--emptybraces no-space
+--maxblanklines 1
+
+# Semicolons
+--semicolons inline
+
+# Redundancy
+--self remove
+--selfrequired
+--importgrouping alpha
+
+# Trailing commas
+--commas always
+
+# Marks
+--markextensions always
+--marktypes always
+
+# Type attributes
+--typeattributes prev-line
+--funcattributes prev-line
+--varattributes preserve
+--storedvarattrs same-line
+--computedvarattrs preserve
+
+# Other
+--stripunusedargs closure-only
+--decimalgrouping 3,6
+--binarygrouping 4,8
+--octalgrouping 4,8
+--hexgrouping 4,8
+--hexliteralcase uppercase
+--exponentcase lowercase
+--patternlet hoist
+
+# Exclude paths (consistent with .swiftlint.yml)
+--exclude DerivedData,.build,Pods,Packages,.swiftpm
+
+# Disabled rules
+--disable trailingCommas
+--disable blankLinesAtEndOfScope
+--disable blankLinesAtStartOfScope

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,165 @@
+# SwiftLint configuration for SwiftUI + MVVM projects
+
+# Paths to include
+included:
+  - Sources
+  - Tests
+
+# Paths to exclude
+excluded:
+  - DerivedData
+  - .build
+  - Pods
+  - Packages
+  - .swiftpm
+
+# ──────────────────────────────────────────────
+# Disabled rules
+# ──────────────────────────────────────────────
+disabled_rules:
+  - trailing_comma           # SwiftFormat handles this
+  - opening_brace            # SwiftFormat handles brace placement
+  - large_tuple              # SwiftUI previews and views often use larger tuples
+  - todo                     # Allow TODO / FIXME comments during development
+  - nesting                  # SwiftUI views commonly nest deeply
+  - type_name               # Allow short or long type names for SwiftUI views
+
+# ──────────────────────────────────────────────
+# Opt-in rules
+# ──────────────────────────────────────────────
+opt_in_rules:
+  - array_init
+  - closure_end_indentation
+  - closure_spacing
+  - collection_alignment
+  - contains_over_filter_count
+  - contains_over_first_not_nil
+  - contains_over_range_nil_comparison
+  - discouraged_object_literal
+  - empty_collection_literal
+  - empty_count
+  - empty_string
+  - enum_case_associated_values_count
+  - explicit_init
+  - extension_access_modifier
+  - fallthrough
+  - fatal_error_message
+  - file_name_no_space
+  - first_where
+  - flatmap_over_map_reduce
+  - identical_operands
+  - implicit_return
+  - joined_default_parameter
+  - last_where
+  - legacy_multiple
+  - literal_expression_end_indentation
+  - lower_acl_than_parent
+  - modifier_order
+  - multiline_arguments
+  - multiline_parameters
+  - operator_usage_whitespace
+  - overridden_super_call
+  - prefer_self_in_static_references
+  - prefer_self_type_over_type_of_self
+  - prefer_zero_over_explicit_init
+  - private_action
+  - private_outlet
+  - prohibited_super_call
+  - reduce_into
+  - redundant_nil_coalescing
+  - redundant_type_annotation
+  - sorted_first_last
+  - toggle_bool
+  - trailing_closure
+  - unneeded_parentheses_in_closure_argument
+  - unowned_variable_capture
+  - vertical_parameter_alignment_on_call
+  - yoda_condition
+
+# ──────────────────────────────────────────────
+# Rule configurations
+# ──────────────────────────────────────────────
+
+# Line length
+line_length:
+  warning: 120
+  error: 200
+  ignores_urls: true
+  ignores_comments: true
+  ignores_interpolated_strings: true
+
+# Function body length
+function_body_length:
+  warning: 50
+  error: 100
+
+# Type body length (generous for SwiftUI views)
+type_body_length:
+  warning: 300
+  error: 500
+
+# File length
+file_length:
+  warning: 500
+  error: 1000
+  ignore_comment_only_lines: true
+
+# Cyclomatic complexity
+cyclomatic_complexity:
+  warning: 15
+  error: 25
+  ignores_case_statements: true
+
+# Function parameter count
+function_parameter_count:
+  warning: 6
+  error: 8
+
+# Identifier name
+identifier_name:
+  min_length:
+    warning: 2
+    error: 1
+  max_length:
+    warning: 50
+    error: 60
+  excluded:
+    - id
+    - x
+    - y
+    - z
+    - i
+    - j
+    - k
+    - to
+    - on
+    - no
+    - ok
+    - up
+
+# Modifier order (consistent with Swift API Design Guidelines)
+modifier_order:
+  preferred_modifier_order:
+    - acl
+    - setterACL
+    - override
+    - dynamic
+    - mutating
+    - nonmutating
+    - lazy
+    - final
+    - required
+    - convenience
+    - typeMethods
+    - owned
+
+# Multiline arguments
+multiline_arguments:
+  only_enforce_after_first_closure_on_first_line: true
+
+# Vertical whitespace
+vertical_whitespace:
+  max_empty_lines: 1
+
+# Reporter
+reporter: xcode

--- a/Mintfile
+++ b/Mintfile
@@ -1,0 +1,2 @@
+realm/SwiftLint@0.63.2
+nicklockwood/SwiftFormat@0.59.1


### PR DESCRIPTION
## Summary
- Add **Mintfile** with SwiftLint 0.63.2 and SwiftFormat 0.59.1 (latest stable versions)
- Add **.swiftlint.yml** configured for SwiftUI + MVVM projects with reasonable thresholds (line_length warning: 120/error: 200, function_body_length warning: 50), useful opt-in rules, and noisy rules disabled for SwiftUI development
- Add **.swiftformat** with 4-space indentation, Swift 6.2, before-first wrapping, and settings consistent with the SwiftLint configuration

## Test plan
- [ ] Verify `mint bootstrap` installs both tools at the pinned versions
- [ ] Run `mint run swiftlint` against the project and confirm configuration is applied
- [ ] Run `mint run swiftformat --lint .` against the project and confirm configuration is applied
- [ ] Confirm no contradictions between `.swiftlint.yml` and `.swiftformat` rules

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)