### PR TITLE
Add Fastlane configuration

### DIFF
--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,7 @@
+# App ID and Apple ID configuration
+# Replace with your actual values
+app_identifier("com.example.yourapp") # The bundle identifier of your app
+apple_id("your@email.com") # Your Apple Developer email
+
+# For more information about the Appfile, see:
+# https://docs.fastlane.tools/advanced/#appfile

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,43 @@
+default_platform(:ios)
+
+platform :ios do
+  # ============================================================
+  # Build
+  # ============================================================
+  desc "Build the app"
+  lane :build do
+    xcodebuild(
+      scheme: ENV["SCHEME"] || "App",
+      configuration: "Debug",
+      build: true,
+      destination: "generic/platform=iOS Simulator"
+    )
+  end
+
+  # ============================================================
+  # Test
+  # ============================================================
+  desc "Run tests"
+  lane :test do
+    run_tests(
+      scheme: ENV["SCHEME"] || "App",
+      device: "iPhone 16",
+      clean: true
+    )
+  end
+
+  # ============================================================
+  # Beta (TestFlight)
+  # ============================================================
+  desc "Build and upload to TestFlight"
+  lane :beta do
+    increment_build_number
+    build_app(
+      scheme: ENV["SCHEME"] || "App",
+      export_method: "app-store"
+    )
+    upload_to_testflight(
+      skip_waiting_for_build_processing: true
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- Add `fastlane/Appfile` with app identifier and Apple ID placeholder configuration
- Add `fastlane/Fastfile` with three lanes: `build` (debug build for simulator), `test` (run tests on iPhone 16), and `beta` (build and upload to TestFlight)

Closes #8

## Test plan
- [ ] Verify `fastlane/Appfile` contains correct placeholder values
- [ ] Verify `fastlane/Fastfile` defines `build`, `test`, and `beta` lanes
- [ ] Verify lanes use `ENV["SCHEME"] || "App"` for scheme configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)