### PR TITLE
Add project.yml, base app, and sample Feature Module

### DIFF
--- a/Sources/App/App.swift
+++ b/Sources/App/App.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct MainApp: SwiftUI.App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Sources/App/ContentView.swift
+++ b/Sources/App/ContentView.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        NavigationStack {
+            SampleView()
+        }
+    }
+}

--- a/Sources/App/Info.plist
+++ b/Sources/App/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <true/>
+    </dict>
+</dict>
+</plist>

--- a/Sources/Features/Sample/Model/SampleItem.swift
+++ b/Sources/Features/Sample/Model/SampleItem.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct SampleItem: Identifiable, Sendable {
+    let id: UUID
+    var title: String
+    var isCompleted: Bool
+    let createdAt: Date
+
+    init(id: UUID = UUID(), title: String, isCompleted: Bool = false, createdAt: Date = .now) {
+        self.id = id
+        self.title = title
+        self.isCompleted = isCompleted
+        self.createdAt = createdAt
+    }
+}

--- a/Sources/Features/Sample/Repository/SampleRepository.swift
+++ b/Sources/Features/Sample/Repository/SampleRepository.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+protocol SampleRepositoryProtocol: Sendable {
+    func fetchItems() async throws -> [SampleItem]
+    func addItem(title: String) async throws -> SampleItem
+    func toggleItem(_ item: SampleItem) async throws -> SampleItem
+    func deleteItem(_ item: SampleItem) async throws
+}
+
+final class SampleRepository: SampleRepositoryProtocol, @unchecked Sendable {
+    private var items: [SampleItem] = []
+
+    func fetchItems() async throws -> [SampleItem] {
+        items
+    }
+
+    func addItem(title: String) async throws -> SampleItem {
+        let item = SampleItem(title: title)
+        items.append(item)
+        return item
+    }
+
+    func toggleItem(_ item: SampleItem) async throws -> SampleItem {
+        guard let index = items.firstIndex(where: { $0.id == item.id }) else {
+            throw SampleError.itemNotFound
+        }
+        items[index].isCompleted.toggle()
+        return items[index]
+    }
+
+    func deleteItem(_ item: SampleItem) async throws {
+        items.removeAll { $0.id == item.id }
+    }
+}
+
+enum SampleError: LocalizedError {
+    case itemNotFound
+
+    var errorDescription: String? {
+        switch self {
+        case .itemNotFound:
+            "Item not found"
+        }
+    }
+}

--- a/Sources/Features/Sample/View/SampleView.swift
+++ b/Sources/Features/Sample/View/SampleView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct SampleView: View {
+    @State private var viewModel = SampleViewModel()
+
+    var body: some View {
+        List {
+            Section {
+                HStack {
+                    TextField("New item", text: $viewModel.newItemTitle)
+                        .textFieldStyle(.roundedBorder)
+                    Button("Add") {
+                        Task { await viewModel.addItem() }
+                    }
+                    .disabled(viewModel.newItemTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+
+            Section {
+                ForEach(viewModel.items) { item in
+                    HStack {
+                        Image(systemName: item.isCompleted ? "checkmark.circle.fill" : "circle")
+                            .foregroundStyle(item.isCompleted ? .green : .secondary)
+                            .onTapGesture {
+                                Task { await viewModel.toggleItem(item) }
+                            }
+                        Text(item.title)
+                            .strikethrough(item.isCompleted)
+                    }
+                }
+                .onDelete { indexSet in
+                    let itemsToDelete = indexSet.map { viewModel.items[$0] }
+                    for item in itemsToDelete {
+                        Task { await viewModel.deleteItem(item) }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Sample")
+        .task { await viewModel.fetchItems() }
+        .overlay {
+            if viewModel.isLoading {
+                ProgressView()
+            }
+        }
+    }
+}

--- a/Sources/Features/Sample/ViewModel/SampleViewModel.swift
+++ b/Sources/Features/Sample/ViewModel/SampleViewModel.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Observation
+
+@Observable
+final class SampleViewModel {
+    private(set) var items: [SampleItem] = []
+    private(set) var isLoading = false
+    var newItemTitle = ""
+    private(set) var errorMessage: String?
+
+    private let repository: SampleRepositoryProtocol
+
+    init(repository: SampleRepositoryProtocol = SampleRepository()) {
+        self.repository = repository
+    }
+
+    func fetchItems() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            items = try await repository.fetchItems()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func addItem() async {
+        let title = newItemTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return }
+        do {
+            let item = try await repository.addItem(title: title)
+            items.append(item)
+            newItemTitle = ""
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func toggleItem(_ item: SampleItem) async {
+        do {
+            let updated = try await repository.toggleItem(item)
+            if let index = items.firstIndex(where: { $0.id == updated.id }) {
+                items[index] = updated
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func deleteItem(_ item: SampleItem) async {
+        do {
+            try await repository.deleteItem(item)
+            items.removeAll { $0.id == item.id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Tests/SampleFeatureTests/SampleViewModelTests.swift
+++ b/Tests/SampleFeatureTests/SampleViewModelTests.swift
@@ -1,0 +1,49 @@
+import Testing
+@testable import App
+
+struct SampleViewModelTests {
+    @Test
+    func addItem() async {
+        let viewModel = SampleViewModel(repository: SampleRepository())
+        viewModel.newItemTitle = "Test Item"
+        await viewModel.addItem()
+
+        #expect(viewModel.items.count == 1)
+        #expect(viewModel.items.first?.title == "Test Item")
+        #expect(viewModel.newItemTitle.isEmpty)
+    }
+
+    @Test
+    func addItemWithEmptyTitle() async {
+        let viewModel = SampleViewModel(repository: SampleRepository())
+        viewModel.newItemTitle = "   "
+        await viewModel.addItem()
+
+        #expect(viewModel.items.isEmpty)
+    }
+
+    @Test
+    func toggleItem() async {
+        let viewModel = SampleViewModel(repository: SampleRepository())
+        viewModel.newItemTitle = "Test"
+        await viewModel.addItem()
+
+        let item = viewModel.items[0]
+        #expect(!item.isCompleted)
+
+        await viewModel.toggleItem(item)
+        #expect(viewModel.items[0].isCompleted)
+    }
+
+    @Test
+    func deleteItem() async {
+        let viewModel = SampleViewModel(repository: SampleRepository())
+        viewModel.newItemTitle = "Test"
+        await viewModel.addItem()
+        #expect(viewModel.items.count == 1)
+
+        let item = viewModel.items[0]
+        await viewModel.deleteItem(item)
+        #expect(viewModel.items.isEmpty)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,39 @@
+name: App
+options:
+  bundleIdPrefix: com.example
+  deploymentTarget:
+    iOS: "17.0"
+  xcodeVersion: "16.0"
+  groupSortPosition: top
+  generateEmptyDirectories: true
+
+settings:
+  base:
+    SWIFT_VERSION: "6.0"
+    SWIFT_STRICT_CONCURRENCY: complete
+
+targets:
+  App:
+    type: application
+    platform: iOS
+    sources:
+      - path: Sources/App
+      - path: Sources/Features
+    settings:
+      base:
+        INFOPLIST_FILE: Sources/App/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.app
+        MARKETING_VERSION: "1.0.0"
+        CURRENT_PROJECT_VERSION: "1"
+
+  AppTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: Tests
+    dependencies:
+      - target: App
+    settings:
+      base:
+        BUNDLE_LOADER: "$(TEST_HOST)"
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/App.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/App"


### PR DESCRIPTION
## Summary
- Add `project.yml` (XcodeGen) with App and AppTests targets, iOS 17.0 deployment target, Swift 6.0, strict concurrency
- Add base SwiftUI app entry point (`MainApp`, `ContentView`) under `Sources/App/`
- Add sample Feature Module under `Sources/Features/Sample/` with MVVM architecture: `SampleItem` model, `SampleRepository` (with protocol), `SampleViewModel` using `@Observable`, and `SampleView`
- Add unit tests for `SampleViewModel` using Swift Testing framework (`import Testing`, `@Test`)

## Test plan
- [ ] Run `xcodegen generate` to produce `App.xcodeproj` from `project.yml`
- [ ] Build the App target for iOS Simulator
- [ ] Run AppTests target and verify all 4 tests pass (addItem, addItemWithEmptyTitle, toggleItem, deleteItem)
- [ ] Launch on Simulator and verify SampleView renders with add/toggle/delete functionality

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)