### PR TITLE
Add utility scripts (clean, bootstrap, lint)

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+info()    { printf "\033[1;34m[INFO]\033[0m  %s\n" "$1"; }
+success() { printf "\033[1;32m[OK]\033[0m    %s\n" "$1"; }
+warn()    { printf "\033[1;33m[WARN]\033[0m  %s\n" "$1"; }
+error()   { printf "\033[1;31m[ERROR]\033[0m %s\n" "$1"; exit 1; }
+
+cd "$PROJECT_DIR"
+
+# Mint bootstrap
+if [ -f "Mintfile" ]; then
+    info "Mint bootstrap を実行しています..."
+    mint bootstrap
+    success "Mint bootstrap 完了"
+else
+    warn "Mintfile が見つかりません。スキップします。"
+fi
+
+# XcodeGen
+if [ -f "project.yml" ]; then
+    info "XcodeGen でプロジェクトを生成しています..."
+    xcodegen generate
+    success "プロジェクトを生成しました"
+else
+    warn "project.yml が見つかりません。XcodeGen をスキップします。"
+fi
+
+# SPM resolve
+info "SPM パッケージを解決しています..."
+xcodebuild -resolvePackageDependencies 2>/dev/null || warn "SPM パッケージ解決をスキップしました"
+success "SPM パッケージ解決完了"
+
+echo ""
+success "bootstrap 完了！ビルドの準備が整いました。"

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+info()    { printf "\033[1;34m[INFO]\033[0m  %s\n" "$1"; }
+success() { printf "\033[1;32m[OK]\033[0m    %s\n" "$1"; }
+warn()    { printf "\033[1;33m[WARN]\033[0m  %s\n" "$1"; }
+
+cd "$PROJECT_DIR"
+
+# Project name from project.yml
+PROJECT_NAME=""
+if [ -f "project.yml" ]; then
+    PROJECT_NAME=$(grep '^name:' project.yml | head -1 | sed 's/name: *//')
+fi
+
+# DerivedData
+info "DerivedData を削除しています..."
+DERIVED_DATA="$HOME/Library/Developer/Xcode/DerivedData"
+if [ -n "$PROJECT_NAME" ]; then
+    find "$DERIVED_DATA" -maxdepth 1 -type d -name "${PROJECT_NAME}-*" -exec rm -rf {} + 2>/dev/null || true
+    success "DerivedData を削除しました（${PROJECT_NAME}）"
+else
+    rm -rf "$DERIVED_DATA"
+    success "DerivedData を全削除しました"
+fi
+
+# SPM local cache
+if [ -d ".build" ]; then
+    rm -rf .build
+    success ".build を削除しました"
+fi
+
+# Package.resolved
+find . -name "Package.resolved" -not -path "./.git/*" -delete 2>/dev/null || true
+success "Package.resolved を削除しました"
+
+# SPM global cache
+SPM_CACHE="$HOME/Library/Caches/org.swift.swiftpm"
+if [ -d "$SPM_CACHE" ]; then
+    rm -rf "$SPM_CACHE"
+    success "SPM グローバルキャッシュを削除しました"
+fi
+
+# Regenerate .xcodeproj
+if [ -f "project.yml" ]; then
+    info "XcodeGen でプロジェクトを再生成しています..."
+    xcodegen generate
+    success "プロジェクトを再生成しました"
+fi
+
+# Re-resolve SPM
+info "SPM パッケージを再解決しています..."
+xcodebuild -resolvePackageDependencies 2>/dev/null || warn "SPM パッケージ解決をスキップしました"
+
+echo ""
+success "クリーンアップ完了！"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+info()    { printf "\033[1;34m[INFO]\033[0m  %s\n" "$1"; }
+success() { printf "\033[1;32m[OK]\033[0m    %s\n" "$1"; }
+warn()    { printf "\033[1;33m[WARN]\033[0m  %s\n" "$1"; }
+error()   { printf "\033[1;31m[ERROR]\033[0m %s\n" "$1"; }
+
+cd "$PROJECT_DIR"
+EXIT_CODE=0
+
+# SwiftFormat
+info "SwiftFormat を実行しています..."
+if command -v mint &>/dev/null && [ -f "Mintfile" ]; then
+    SWIFTFORMAT_CMD="mint run swiftformat"
+else
+    SWIFTFORMAT_CMD="swiftformat"
+fi
+
+if $SWIFTFORMAT_CMD . 2>/dev/null; then
+    success "SwiftFormat 完了"
+else
+    warn "SwiftFormat の実行に失敗しました"
+    EXIT_CODE=1
+fi
+
+# SwiftLint
+info "SwiftLint を実行しています..."
+if command -v mint &>/dev/null && [ -f "Mintfile" ]; then
+    SWIFTLINT_CMD="mint run swiftlint"
+else
+    SWIFTLINT_CMD="swiftlint"
+fi
+
+if $SWIFTLINT_CMD lint --quiet 2>/dev/null; then
+    success "SwiftLint 完了（違反なし）"
+else
+    warn "SwiftLint で違反が検出されました"
+    EXIT_CODE=1
+fi
+
+echo ""
+if [ $EXIT_CODE -eq 0 ]; then
+    success "すべてのチェックをパスしました！"
+else
+    error "一部のチェックで問題が検出されました。上記の出力を確認してください。"
+fi
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary
- Add `scripts/clean.sh` — cleans DerivedData, SPM caches, Package.resolved, and regenerates the Xcode project
- Add `scripts/bootstrap.sh` — runs Mint bootstrap, XcodeGen project generation, and SPM dependency resolution
- Add `scripts/lint.sh` — runs SwiftFormat and SwiftLint (via Mint if available), reporting results with colored output

All scripts use `set -euo pipefail`, colored log helpers, and are marked executable.

Closes #10

## Test plan
- [ ] Run `scripts/bootstrap.sh` and verify Mint packages install, project generates, and SPM resolves
- [ ] Run `scripts/lint.sh` and verify SwiftFormat and SwiftLint execute with correct pass/fail reporting
- [ ] Run `scripts/clean.sh` and verify DerivedData and caches are removed, project is regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)