### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Mint
+        run: brew install mint
+
+      - name: Bootstrap tools
+        run: mint bootstrap
+
+      - name: Run SwiftFormat
+        run: mint run swiftformat --lint .
+
+      - name: Run SwiftLint
+        run: mint run swiftlint lint --strict --quiet
+
+  build-and-test:
+    name: Build & Test
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Mint
+        run: brew install mint
+
+      - name: Bootstrap tools
+        run: mint bootstrap
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Build
+        run: |
+          xcodebuild build \
+            -project App.xcodeproj \
+            -scheme App \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -configuration Debug \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Test
+        run: |
+          xcodebuild test \
+            -project App.xcodeproj \
+            -scheme AppTests \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -configuration Debug \
+            CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` with two jobs: **Lint** and **Build & Test**
- Lint job runs SwiftFormat and SwiftLint via Mint on `macos-15`
- Build & Test job generates the Xcode project with XcodeGen, then builds and runs tests against iPhone 16 simulator
- Workflow triggers on pull requests and pushes to `main`, with concurrency grouping to cancel in-progress runs

Closes #11

## Test plan
- [ ] Verify the workflow runs on a PR targeting `main`
- [ ] Confirm the lint job passes SwiftFormat and SwiftLint checks
- [ ] Confirm the build-and-test job successfully generates the project, builds, and runs tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)