### PR TITLE
Add Git hooks (pre-commit, commit-msg)

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+COMMIT_MSG_FILE="$1"
+COMMIT_MSG=$(head -1 "$COMMIT_MSG_FILE")
+
+# Conventional Commits pattern
+# type(scope): subject
+# type: subject
+PATTERN='^(feat|fix|docs|style|refactor|test|chore|build|ci|perf|revert)(\(.+\))?: .+$'
+
+# Allow merge commits
+if echo "$COMMIT_MSG" | grep -qE '^Merge '; then
+    exit 0
+fi
+
+# Allow revert commits
+if echo "$COMMIT_MSG" | grep -qE '^Revert '; then
+    exit 0
+fi
+
+if ! echo "$COMMIT_MSG" | grep -qE "$PATTERN"; then
+    echo ""
+    echo "commit-msg: コミットメッセージが Conventional Commits 形式に準拠していません。"
+    echo ""
+    echo "  形式: <type>(<scope>): <subject>"
+    echo ""
+    echo "  type: feat, fix, docs, style, refactor, test, chore, build, ci, perf, revert"
+    echo "  scope: 省略可"
+    echo "  subject: 変更内容の簡潔な説明"
+    echo ""
+    echo "  例: feat(auth): Add login screen"
+    echo "      fix: Resolve crash on launch"
+    echo "      chore(deps): Update SwiftLint to 0.57.1"
+    echo ""
+    exit 1
+fi

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Run lint only on staged Swift files
+STAGED_SWIFT_FILES=$(git diff --cached --name-only --diff-filter=ACM -- '*.swift' || true)
+
+if [ -z "$STAGED_SWIFT_FILES" ]; then
+    exit 0
+fi
+
+echo "pre-commit: SwiftFormat + SwiftLint を実行しています..."
+
+# Run lint script
+if ! "$REPO_DIR/scripts/lint.sh"; then
+    echo ""
+    echo "pre-commit: lint エラーがあります。修正してから再度コミットしてください。"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `hooks/pre-commit` that runs `scripts/lint.sh` (SwiftFormat + SwiftLint) on staged Swift files before each commit
- Add `hooks/commit-msg` that validates commit messages against Conventional Commits format
- Hooks are placed in `hooks/` directory (activated via `git config core.hooksPath hooks`)

## Test plan
- [ ] Run `git config core.hooksPath hooks` to activate the hooks
- [ ] Verify `pre-commit` hook runs lint on commits with staged `.swift` files
- [ ] Verify `pre-commit` hook is skipped when no `.swift` files are staged
- [ ] Verify `commit-msg` hook rejects non-Conventional Commits messages
- [ ] Verify `commit-msg` hook accepts valid messages like `feat: Add feature`
- [ ] Verify `commit-msg` hook allows merge and revert commits

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)