### PR TITLE
refactor(ci): Migrate build and test to Fastlane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,32 +35,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Mint
-        run: brew install mint
+      - name: Install tools
+        run: brew install mint xcodegen
 
       - name: Bootstrap tools
         run: mint bootstrap
-
-      - name: Install XcodeGen
-        run: brew install xcodegen
 
       - name: Generate Xcode project
         run: xcodegen generate
 
       - name: Build
-        run: |
-          xcodebuild build \
-            -project App.xcodeproj \
-            -scheme App \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
-            -configuration Debug \
-            CODE_SIGNING_ALLOWED=NO
+        run: fastlane build
 
       - name: Test
-        run: |
-          xcodebuild test \
-            -project App.xcodeproj \
-            -scheme AppTests \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
-            -configuration Debug \
-            CODE_SIGNING_ALLOWED=NO
+        run: fastlane test

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,7 +10,8 @@ platform :ios do
       scheme: ENV["SCHEME"] || "App",
       configuration: "Debug",
       build: true,
-      destination: "generic/platform=iOS Simulator"
+      destination: "generic/platform=iOS Simulator",
+      xcargs: "CODE_SIGNING_ALLOWED=NO"
     )
   end
 
@@ -22,7 +23,8 @@ platform :ios do
     run_tests(
       scheme: ENV["SCHEME"] || "App",
       device: "iPhone 16",
-      clean: true
+      clean: true,
+      xcargs: "CODE_SIGNING_ALLOWED=NO"
     )
   end
 


### PR DESCRIPTION
## Summary
- CI の `xcodebuild` 直呼びを `fastlane build` / `fastlane test` に置き換え
- Fastfile の `build` / `test` レーンに `CODE_SIGNING_ALLOWED=NO` を追加
- `test` レーンのスキームを `AppTests` → `App` に修正（hosted unit test は app scheme を使う）

## Test plan
- [ ] CI ワークフローが `fastlane build` / `fastlane test` で正常に動作すること

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)