### PR TITLE
refactor(setup): extraKnownMarketplacesによるプラグイン設定の宣言的管理に移行

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "extraKnownMarketplaces": [
+    "inoue0124/ios-claude-plugins"
+  ],
+  "enabledPlugins": {
+    "ios-architecture@ios-claude-plugins": true,
+    "team-conventions@ios-claude-plugins": true,
+    "swift-code-quality@ios-claude-plugins": true,
+    "swift-testing@ios-claude-plugins": true,
+    "github-workflow@ios-claude-plugins": true,
+    "code-review-assist@ios-claude-plugins": true,
+    "ios-onboarding@ios-claude-plugins": true,
+    "feature-module-gen@ios-claude-plugins": true,
+    "ios-distribution@ios-claude-plugins": true,
+    "feature-implementation@ios-claude-plugins": true
+  },
+  "mcpServers": {
+    "XcodeBuildMCP": {
+      "command": "npx",
+      "args": ["-y", "xcodebuildmcp@latest", "mcp"]
+    },
+    "xcodeproj": {
+      "command": "docker",
+      "args": ["run", "--pull=always", "--rm", "-i", "-v", "$PWD:/workspace", "ghcr.io/giginet/xcodeproj-mcp-server:latest", "/workspace"]
+    }
+  }
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -109,13 +109,32 @@ fi
 SETTINGS_DIR="$PROJECT_DIR/.claude"
 SETTINGS_FILE="$SETTINGS_DIR/settings.json"
 
-# Skip if settings.json already contains mcpServers
-if [ -f "$SETTINGS_FILE" ] && grep -q '"mcpServers"' "$SETTINGS_FILE"; then
-    info ".claude/settings.json に既存の MCP 設定が見つかりました。スキップします。"
+# Regenerate settings.json only if it is missing (e.g. deleted by user).
+# The repository ships a pre-configured .claude/settings.json that includes
+# mcpServers, enabledPlugins, and extraKnownMarketplaces.  When a user
+# trusts this project folder, Claude Code will auto-prompt to register the
+# ios-claude-plugins marketplace via extraKnownMarketplaces.
+if [ -f "$SETTINGS_FILE" ]; then
+    info ".claude/settings.json は既に存在します。スキップします。"
 else
     mkdir -p "$SETTINGS_DIR"
     cat > "$SETTINGS_FILE" << 'SETTINGS_EOF'
 {
+  "extraKnownMarketplaces": [
+    "inoue0124/ios-claude-plugins"
+  ],
+  "enabledPlugins": {
+    "ios-architecture@ios-claude-plugins": true,
+    "team-conventions@ios-claude-plugins": true,
+    "swift-code-quality@ios-claude-plugins": true,
+    "swift-testing@ios-claude-plugins": true,
+    "github-workflow@ios-claude-plugins": true,
+    "code-review-assist@ios-claude-plugins": true,
+    "ios-onboarding@ios-claude-plugins": true,
+    "feature-module-gen@ios-claude-plugins": true,
+    "ios-distribution@ios-claude-plugins": true,
+    "feature-implementation@ios-claude-plugins": true
+  },
   "mcpServers": {
     "XcodeBuildMCP": {
       "command": "npx",
@@ -128,42 +147,11 @@ else
   }
 }
 SETTINGS_EOF
-    success "XcodeBuildMCP + xcodeproj を .claude/settings.json に設定しました"
+    success ".claude/settings.json を生成しました（MCP + プラグイン設定）"
 fi
 
 # ============================================================
-# 4. ios-claude-plugins installation
-# ============================================================
-info "=== ios-claude-plugins ==="
-if check_command claude; then
-    info "ios-claude-plugins マーケットプレースを登録しています..."
-    if claude plugin marketplace add inoue0124/ios-claude-plugins 2>/dev/null; then
-        success "マーケットプレースを登録しました"
-        info "プラグインをインストールしています..."
-        PLUGIN_FAILED=false
-        for plugin in ios-architecture team-conventions swift-code-quality swift-testing github-workflow code-review-assist ios-onboarding feature-module-gen ios-distribution feature-implementation; do
-            if claude plugin install "$plugin" --scope project 2>/dev/null; then
-                success "$plugin をインストールしました"
-            else
-                warn "$plugin のインストールに失敗しました"
-                PLUGIN_FAILED=true
-            fi
-        done
-        if [ "$PLUGIN_FAILED" = true ]; then
-            warn "一部プラグインのインストールに失敗しました。Claude Code 内で /plugin marketplace add inoue0124/ios-claude-plugins を実行してください。"
-        fi
-    else
-        warn "マーケットプレースの登録に失敗しました。Claude Code 内で以下を実行してください:"
-        echo ""
-        echo "  /plugin marketplace add inoue0124/ios-claude-plugins"
-        echo ""
-    fi
-else
-    warn "Claude Code が見つかりません。npm install -g @anthropic-ai/claude-code でインストールしてください。"
-fi
-
-# ============================================================
-# 5. Project generation
+# 4. Project generation
 # ============================================================
 info "=== プロジェクト生成 ==="
 cd "$PROJECT_DIR"
@@ -192,7 +180,7 @@ else
 fi
 
 # ============================================================
-# 6. Git hooks installation
+# 5. Git hooks installation
 # ============================================================
 info "=== Git hooks ==="
 if [ -d "$PROJECT_DIR/scripts/hooks" ]; then


### PR DESCRIPTION
## Summary

- setup.sh の `claude plugin marketplace add` / `claude plugin install` による命令的インストールを廃止
- `.claude/settings.json` の `extraKnownMarketplaces` + `enabledPlugins` による宣言的設定に移行
- `.claude/settings.json` をリポジトリにコミット（テンプレートクローン直後から利用可能）

## Changes

- `.claude/settings.json`: `extraKnownMarketplaces` を追加、リポジトリにコミット
- `scripts/setup.sh`: プラグインインストールセクション（旧セクション4）を削除、`claude` CLI 依存を排除

## Test plan

- [x] `bash -n scripts/setup.sh` シンタックスチェック OK
- [x] `bash scripts/setup.sh` 実行でセットアップ完了まで正常動作確認
- [x] `.claude/settings.json` に `extraKnownMarketplaces`, `enabledPlugins`, `mcpServers` が正しく設定

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)