### PR TITLE
fix(setup): extraKnownMarketplacesのフォーマット修正

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,12 @@
 {
-  "extraKnownMarketplaces": [
-    "inoue0124/ios-claude-plugins"
-  ],
+  "extraKnownMarketplaces": {
+    "ios-claude-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "inoue0124/ios-claude-plugins"
+      }
+    }
+  },
   "enabledPlugins": {
     "ios-architecture@ios-claude-plugins": true,
     "team-conventions@ios-claude-plugins": true,

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -120,9 +120,14 @@ else
     mkdir -p "$SETTINGS_DIR"
     cat > "$SETTINGS_FILE" << 'SETTINGS_EOF'
 {
-  "extraKnownMarketplaces": [
-    "inoue0124/ios-claude-plugins"
-  ],
+  "extraKnownMarketplaces": {
+    "ios-claude-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "inoue0124/ios-claude-plugins"
+      }
+    }
+  },
   "enabledPlugins": {
     "ios-architecture@ios-claude-plugins": true,
     "team-conventions@ios-claude-plugins": true,


### PR DESCRIPTION
## Summary

- `extraKnownMarketplaces` のフォーマットを配列からオブジェクト形式に修正
- `.claude/settings.json` と `scripts/setup.sh` 内のフォールバック生成の両方を修正

## Before (incorrect)
```json
"extraKnownMarketplaces": [
  "inoue0124/ios-claude-plugins"
]
```

## After (correct)
```json
"extraKnownMarketplaces": {
  "ios-claude-plugins": {
    "source": {
      "source": "github",
      "repo": "inoue0124/ios-claude-plugins"
    }
  }
}
```

## Test plan

- [x] `bash -n scripts/setup.sh` シンタックスチェック OK
- [x] `.claude/settings.json` がドキュメントの形式に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)