### PR TITLE
feat(setup): プラグイン一覧をマーケットプレースから動的取得

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -149,8 +149,15 @@ if check_command claude; then
     fi
 
     info "プラグインをインストールしています..."
+    MARKETPLACE_NAME="ios-claude-plugins"
+    PLUGINS=$(claude plugin list --available --json 2>/dev/null \
+        | jq -r ".available[] | select(.marketplaceName == \"$MARKETPLACE_NAME\") | .name" 2>/dev/null || true)
+    if [ -z "$PLUGINS" ]; then
+        warn "プラグイン一覧を動的取得できませんでした。既知のプラグインをインストールします。"
+        PLUGINS="ios-architecture team-conventions swift-code-quality swift-testing github-workflow code-review-assist ios-onboarding feature-module-gen ios-distribution feature-implementation spec-driven-dev"
+    fi
     PLUGIN_FAILED=false
-    for plugin in ios-architecture team-conventions swift-code-quality swift-testing github-workflow code-review-assist ios-onboarding feature-module-gen ios-distribution feature-implementation; do
+    for plugin in $PLUGINS; do
         if claude plugin install "$plugin" --scope project 2>/dev/null; then
             success "$plugin をインストールしました"
         else


### PR DESCRIPTION
## Summary

- `setup.sh` のプラグインインストールリストをハードコードから動的取得に変更
- `claude plugin list --available --json` + `jq` で `ios-claude-plugins` マーケットプレースのプラグインを自動検出
- CLI が利用不可の場合はフォールバックとして既知のプラグインリスト（`spec-driven-dev` 含む）を使用

## Test plan

- [x] `bash -n scripts/setup.sh` でシンタックスチェック通過
- [ ] `bash scripts/setup.sh` でプラグイン動的取得 → インストールが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)