### PR TITLE
fix(template): Add UILaunchScreen to Info.plist

### DIFF
--- a/Sources/App/Info.plist
+++ b/Sources/App/Info.plist
@@ -21,5 +21,7 @@
         <key>UIApplicationSupportsMultipleScenes</key>
         <true/>
     </dict>
+    <key>UILaunchScreen</key>
+    <dict/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- `Info.plist` に `UILaunchScreen` の空辞書を追加
- iOS 14 以降、このキーがないとフルスクリーン表示にならず黒帯が出る問題を修正

## Test plan
- [ ] テンプレートからプロジェクト生成後、シミュレータで黒帯が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)