### PR TITLE
fix(ci): pre-built バイナリで CI 高速化 + lint --strict 統一

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,36 +10,45 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SWIFTLINT_VERSION: "0.63.2"
+  SWIFTFORMAT_VERSION: "0.59.1"
+
 jobs:
   lint:
     name: Lint
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Install Mint
-        run: brew install mint
+      - name: Install SwiftLint
+        run: |
+          curl -sL "https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}/portable_swiftlint.zip" -o swiftlint.zip
+          unzip -o swiftlint.zip
+          sudo cp swiftlint /usr/local/bin/swiftlint
+          swiftlint version
 
-      - name: Bootstrap tools
-        run: mint bootstrap
+      - name: Install SwiftFormat
+        run: |
+          curl -sL "https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat.zip" -o swiftformat.zip
+          unzip -o swiftformat.zip
+          sudo cp swiftformat /usr/local/bin/swiftformat
+          swiftformat --version
 
       - name: Run SwiftFormat
-        run: mint run swiftformat --lint .
+        run: swiftformat --lint .
 
       - name: Run SwiftLint
-        run: mint run swiftlint lint --strict --quiet
+        run: swiftlint lint --strict --quiet
 
   build-and-test:
     name: Build & Test
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Install tools
-        run: brew install mint xcodegen
-
-      - name: Bootstrap tools
-        run: mint bootstrap
+      - name: Install xcodegen
+        run: brew install xcodegen
 
       - name: Generate Xcode project
         run: xcodegen generate

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -35,7 +35,7 @@ else
     SWIFTLINT_CMD="swiftlint"
 fi
 
-if $SWIFTLINT_CMD lint --quiet 2>/dev/null; then
+if $SWIFTLINT_CMD lint --strict --quiet 2>/dev/null; then
     success "SwiftLint 完了（違反なし）"
 else
     warn "SwiftLint で違反が検出されました"


### PR DESCRIPTION
## Summary
- CI の lint ジョブで `mint bootstrap`（ソースビルド）をやめ、GitHub Releases の pre-built バイナリを直接ダウンロードする形に変更。`mint bootstrap` がタイムアウトする問題を解消
- `scripts/lint.sh` に `--strict` を追加し、CI の `--strict` と統一。ローカルで warning が通過して CI で落ちる不一致を解消
- `actions/checkout` を v6 に更新
- build-and-test ジョブから不要な Mint 依存を削除

## 背景
kokorouta プロジェクトで以下の問題が発生:
1. `mint bootstrap` で SwiftLint のソースビルドに長時間かかり CI がタイムアウト
2. ローカルの `lint.sh` に `--strict` がなく、CI では `--strict` 付きのため SwiftLint の warning レベル違反がローカルでは通過するが CI で落ちる

## Test plan
- [ ] CI の lint ジョブが pre-built バイナリで正常に動作することを確認
- [ ] CI の build-and-test ジョブが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)