### PR TITLE
fix(ci): Fastlane の xcodebuild タイムアウトを延長

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,12 @@ jobs:
 
       - name: Build
         run: fastlane build
+        env:
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60
+          FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 5
 
       - name: Test
         run: fastlane test
+        env:
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60
+          FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 5


### PR DESCRIPTION
## Summary
- `fastlane build` / `fastlane test` で `xcodebuild -showBuildSettings` がデフォルト3秒でタイムアウトする問題を修正
- `FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 60` と `FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 5` を設定

## 背景
Firebase 等の SPM パッケージが多いプロジェクトでは、パッケージ解決後の `showBuildSettings` に3秒以上かかり CI が失敗する

## Test plan
- [ ] CI の build-and-test ジョブが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)