### PR TITLE
Add release lane and beta local/CI separation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,17 +29,53 @@ platform :ios do
   end
 
   # ============================================================
-  # Beta (TestFlight)
+  # Beta - Local (TestFlight)
   # ============================================================
-  desc "Build and upload to TestFlight"
+  desc "Upload to TestFlight (local)"
   lane :beta do
-    increment_build_number
+    increment_build_number(xcodeproj: "App.xcodeproj")
     build_app(
       scheme: ENV["SCHEME"] || "App",
-      export_method: "app-store"
+      export_options: "ExportOptions.plist",
+      xcargs: "DEVELOPMENT_TEAM=#{ENV['TEAM_ID'] || 'YOUR_TEAM_ID'} -allowProvisioningUpdates"
     )
     upload_to_testflight(
+      apple_id: ENV["APPLE_ID"] || "your@email.com",
       skip_waiting_for_build_processing: true
+    )
+  end
+
+  # ============================================================
+  # Beta - CI (TestFlight with ASC API Key)
+  # ============================================================
+  desc "Upload to TestFlight (CI with ASC API Key)"
+  lane :beta_ci do
+    api_key = app_store_connect_api_key(
+      key_id: ENV["ASC_KEY_ID"],
+      issuer_id: ENV["ASC_ISSUER_ID"],
+      key_filepath: ENV["ASC_KEY_PATH"]
+    )
+    increment_build_number(xcodeproj: "App.xcodeproj")
+    build_app(
+      scheme: ENV["SCHEME"] || "App",
+      export_options: "ExportOptions.plist"
+    )
+    upload_to_testflight(api_key: api_key, skip_waiting_for_build_processing: true)
+  end
+
+  # ============================================================
+  # Release (App Store)
+  # ============================================================
+  desc "Submit to App Store"
+  lane :release do
+    build_app(
+      scheme: ENV["SCHEME"] || "App",
+      export_options: "ExportOptions.plist"
+    )
+    upload_to_app_store(
+      skip_screenshots: true,
+      skip_metadata: false,
+      force: true
     )
   end
 end


### PR DESCRIPTION
## Summary
- Split the existing `beta` lane into a local variant (`beta`) using `-allowProvisioningUpdates` for automatic signing and a CI variant (`beta_ci`) using App Store Connect API key authentication
- Added a new `release` lane for App Store submission with `upload_to_app_store`
- Updated `increment_build_number` and `build_app` calls to use explicit `xcodeproj` and `export_options` parameters

## Test plan
- [ ] Verify `fastlane beta` runs locally with correct provisioning and TestFlight upload
- [ ] Verify `fastlane beta_ci` works in CI with ASC_KEY_ID, ASC_ISSUER_ID, and ASC_KEY_PATH environment variables
- [ ] Verify `fastlane release` builds and submits to App Store
- [ ] Confirm existing `build` and `test` lanes are unchanged and still function correctly

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)