### PR TITLE
docs: README の MCP 設定パスを .mcp.json に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ claude
    - gh CLI（GitHub CLI）
 3. **MCP サーバーの自動セットアップ**
    - Node.js / Docker を自動インストール
-   - `.claude/settings.json` に XcodeBuildMCP / xcodeproj-mcp-server を設定
+   - `.mcp.json` に XcodeBuildMCP / xcodeproj-mcp-server を設定
 4. **ios-claude-plugins のインストール**
    - マーケットプレース登録 + 全10プラグインを自動インストール
 5. **プロジェクト生成**


### PR DESCRIPTION
## Summary
- README の MCP 設定ファイル記述を `.claude/settings.json` から `.mcp.json` に修正
- ドキュメントと `scripts/setup.sh` の挙動を一致

## Related
- Closes #65
